### PR TITLE
Correct WP_Tiles_Settings_Config::dropdowns decleration

### DIFF
--- a/wp-tiles-admin.php
+++ b/wp-tiles-admin.php
@@ -40,7 +40,7 @@ class WP_Tiles_Settings_Config
         );
     }
 
-    protected function dropdowns() {
+    protected static function dropdowns() {
         $cats = get_categories();
         $cats_a = array( "" => "All");
         foreach ( $cats as $cat ) {


### PR DESCRIPTION
WP_Tiles_Settings_Config::dropdowns is called statically, but not declared as such resulting in a PHP error.
