### PR TITLE
Check that $el is defined for #resizeParent()

### DIFF
--- a/assets/js/wp-tiles.js
+++ b/assets/js/wp-tiles.js
@@ -17,9 +17,11 @@
     },
 
     resizeParent: function($el, padding) {
-      var tiles = $el.children('.wp-tiles-tile'),
-          tileOffsetTop = parseInt ( $el.offset().top ),
-          max = 0, newHeight;
+      var tiles = $el.children('.wp-tiles-tile');
+      var tileOffsetTop = $el.offset();
+      tileOffsetTop = tileOffsetTop ? parseInt( tileOffsetTop.top ) : 0;
+      var max = 0;
+      var newHeight;
 
       // Iterates over every tile to find the bottom. Is there a faster way?
       tiles.each(function(){


### PR DESCRIPTION
This is a fix for https://github.com/mgmartel/WP-Tiles/issues/13, but I have no idea how you have your `wp-tiles.js` => `wp-tiles.min.js` compression setup.

For some reason, running `wp-tiles.js` gets `Tiles` undefined errors. I noticed that at the top of the min file there is a line with `var Tiles = {};` and that isn't in the regular `wp-tiles.js` file.

I've added a small check that `$el.offset()` exists, and it returns `0` for the `tileOffsetTop` value if it doesn't. I would've run whatever compression script you do afterwards, but I have no idea how to.

Hope this helps
