### PR TITLE
PHP deprecation notice, missing constructor

### DIFF
--- a/vafpress-framework/includes/wpalchemy/MetaBox.php
+++ b/vafpress-framework/includes/wpalchemy/MetaBox.php
@@ -450,6 +450,9 @@ class WPAlchemy_MetaBox
 	 */
 	var $_loop_data;
 	
+	function __construct() {
+	}
+	
 	function WPAlchemy_MetaBox($arr)
 	{
 		$this->_loop_data = new stdClass;


### PR DESCRIPTION
`PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; WPAlchemy_MetaBox has a deprecated constructor in /wp-content/plugins/wp-tiles/vafpress-framework/includes/wpalchemy/MetaBox.php on line 61`